### PR TITLE
Added support for all column name formats

### DIFF
--- a/ClickHouse.Client.Tests/BulkCopyTests.cs
+++ b/ClickHouse.Client.Tests/BulkCopyTests.cs
@@ -79,5 +79,23 @@ namespace ClickHouse.Client.Tests
 
             using var reader = await connection.ExecuteReaderAsync($"SELECT * from {targetTable}");
         }
+
+        [Test]
+        public async Task ShouldExecuteInsertWithBacktickedColumns()
+        {
+            var targetTable = $"temp.backticked_columns";
+
+            await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
+            await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (`field.id` Nullable(UInt8), `@value` Nullable(UInt8)) ENGINE Memory");
+
+            using var bulkCopy = new ClickHouseBulkCopy(connection)
+            {
+                DestinationTableName = targetTable,
+            };
+
+            await bulkCopy.WriteToServerAsync(Enumerable.Repeat(new object[] { 5, 5 }, 5), new[] { "`field.id`, `@value`" });
+
+            using var reader = await connection.ExecuteReaderAsync($"SELECT * FROM {targetTable}");
+        }
     }
 }

--- a/ClickHouse.Client/Copy/ClickHouseBulkCopy.cs
+++ b/ClickHouse.Client/Copy/ClickHouseBulkCopy.cs
@@ -88,12 +88,12 @@ namespace ClickHouse.Client.Copy
             }
 
             ClickHouseType[] columnTypes = null;
-            string[] columnNames = null;
+            string[] columnNames = columns?.ToArray();
 
             using (var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync($"SELECT {GetColumnsExpression(columns)} FROM {DestinationTableName} LIMIT 0"))
             {
                 columnTypes = reader.GetClickHouseColumnTypes();
-                columnNames = reader.GetColumnNames();
+                columnNames ??= reader.GetColumnNames();
             }
 
             var tasks = new Task[MaxDegreeOfParallelism];


### PR DESCRIPTION
Think, it's a bit of a flaw here in bulk insertion. I can't pass column names with backticks, for example. Moreover, it seems that passed column names are used to get absolutely the same column names without any validation, so why not to use it directly.