### PR TITLE
Improved BulkCopy performance

### DIFF
--- a/ClickHouse.Client/ADO/ClickHouseCommand.cs
+++ b/ClickHouse.Client/ADO/ClickHouseCommand.cs
@@ -169,11 +169,11 @@ namespace ClickHouse.Client.ADO
             postMessage.Content = content;
 
             var response = await connection.HttpClient.SendAsync(postMessage, HttpCompletionOption.ResponseHeadersRead, token).ConfigureAwait(false);
-            QueryId = ExtractQueryId(response);
+            QueryId = ClickHouseCommand.ExtractQueryId(response);
             return await ClickHouseConnection.HandleError(response, sqlQuery).ConfigureAwait(false);
         }
 
-        private string ExtractQueryId(HttpResponseMessage response)
+        private static string ExtractQueryId(HttpResponseMessage response)
         {
             const string queryIdHeader = "X-ClickHouse-Query-Id";
             if (response.Headers.Contains(queryIdHeader))

--- a/ClickHouse.Client/Copy/ClickHouseBulkCopy.cs
+++ b/ClickHouse.Client/Copy/ClickHouseBulkCopy.cs
@@ -100,7 +100,7 @@ namespace ClickHouse.Client.Copy
             ClickHouseType[] columnTypes = null;
             string[] columnNames = columns?.ToArray();
 
-            using (var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync($"SELECT {GetColumnsExpression(columns)} FROM {DestinationTableName} LIMIT 0").ConfigureAwait(false))
+            using (var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync($"SELECT {GetColumnsExpression(columns)} FROM {DestinationTableName} WHERE 1=0").ConfigureAwait(false))
             {
                 columnTypes = reader.GetClickHouseColumnTypes();
                 columnNames ??= reader.GetColumnNames();


### PR DESCRIPTION
Moved serialization to main thread to reduce GC load per #60
Before: 6'222'300 rows/s
After: 11'620'640 rows/s