### PR TITLE
Switch to NSubstitute due to privacy concerns

### DIFF
--- a/ClickHouse.Client.Tests/ClickHouse.Client.Tests.csproj
+++ b/ClickHouse.Client.Tests/ClickHouse.Client.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.143" />
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/ClickHouse.Client.Tests/Formats/PeekableStreamWrapperTests.cs
+++ b/ClickHouse.Client.Tests/Formats/PeekableStreamWrapperTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using ClickHouse.Client.Formats;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace ClickHouse.Client.Tests.Formats;
@@ -10,31 +10,27 @@ public class PeekableStreamWrapperTests
     [Test]
     public void PeekableStreamWrapperTestSuite()
     {
-        var streamMock = new Mock<Stream>();
-        using var wrapper = new PeekableStreamWrapper(streamMock.Object);
+        var streamMock = Substitute.For<Stream>();
+        using var wrapper = new PeekableStreamWrapper(streamMock);
 
-        streamMock.Setup(x => x.CanRead).Returns(true);
-        Assert.AreEqual(true, wrapper.CanRead);
 
-        streamMock.Setup(x => x.CanWrite).Returns(false);
-        Assert.AreEqual(false, wrapper.CanWrite);
+        streamMock.CanSeek.Returns(false);
+        streamMock.CanRead.Returns(true);
+        streamMock.CanWrite.Returns(false);
+        streamMock.Length.Returns(999999);
 
-        streamMock.Setup(x => x.CanSeek).Returns(false);
         Assert.AreEqual(false, wrapper.CanSeek);
-
-        streamMock.Setup(x => x.Length).Returns(999999);
+        Assert.AreEqual(true, wrapper.CanRead);
+        Assert.AreEqual(false, wrapper.CanWrite);
         Assert.AreEqual(999999, wrapper.Length);
 
-        streamMock.Setup(x => x.Flush());
         wrapper.Flush();
-        streamMock.Verify(m => m.Flush(), Times.Once());
+        streamMock.Received().Flush();
 
-        streamMock.Setup(x => x.SetLength(123456));
         wrapper.SetLength(123456);
-        streamMock.Verify(m => m.SetLength(123456), Times.Once());
+        streamMock.Received().SetLength(123456);
 
-        streamMock.Setup(x => x.Seek(1, SeekOrigin.Begin));
         wrapper.Seek(1, SeekOrigin.Begin);
-        streamMock.Verify(m => m.Seek(1, SeekOrigin.Begin), Times.Once());
+        streamMock.Received().Seek(1, SeekOrigin.Begin);
     }
 }


### PR DESCRIPTION
Moq generates privacy concerns, and advanced functiuonality is not used: https://github.com/moq/moq/issues/1372