### PR TITLE
fix writing fixed strings with utf8 chars count not equal to byte count

### DIFF
--- a/ClickHouse.Client/Types/FixedStringType.cs
+++ b/ClickHouse.Client/Types/FixedStringType.cs
@@ -29,7 +29,8 @@ internal class FixedStringType : ParameterizedType
     public override void Write(ExtendedBinaryWriter writer, object value)
     {
         var @string = Convert.ToString(value, CultureInfo.InvariantCulture);
-        var stringBytes = new byte[Length];
+        var bytesGiven = Encoding.UTF8.GetByteCount(@string);
+        var stringBytes = new byte[bytesGiven];
         Encoding.UTF8.GetBytes(@string, 0, @string.Length, stringBytes, 0);
         writer.Write(stringBytes);
     }


### PR DESCRIPTION
> To calculate the exact array size required by [GetBytes](https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getbytes?view=net-8.0) to store the resulting bytes, call the [GetByteCount](https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getbytecount?view=net-8.0) method. To calculate the maximum array size, call the [GetMaxByteCount](https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getmaxbytecount?view=net-8.0) method. The [GetByteCount](https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getbytecount?view=net-8.0) method generally allows allocation of less memory, while the [GetMaxByteCount](https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getmaxbytecount?view=net-8.0) method generally executes faster.

Original exception was that destination buffer was too small. I guess it should be safe to change it.