### PR TITLE
fix. SQL statements placed in Url parameters are recognized by the ne…

### DIFF
--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -235,9 +235,8 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
 
         try
         {
-            var uriBuilder = CreateUriBuilder();
-            uriBuilder.CustomParameters.Add("query", versionQuery);
-            var request = new HttpRequestMessage(HttpMethod.Get, uriBuilder.ToString());
+            var uriBuilder = CreateUriBuilder(versionQuery);
+            var request = new HttpRequestMessage(HttpMethod.Post, uriBuilder.ToString());
             AddDefaultHttpHeaders(request.Headers);
             var response = await HandleError(await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false), versionQuery, activity).ConfigureAwait(false);
 #if NET5_0_OR_GREATER


### PR DESCRIPTION
你好，很抱歉我的英语不是很好，请允许我用中文表达。在访问Clickhouse数据时，Open()方法内通过Url参数传递`SELECT version(), timezone() FORMAT TSV` 查询版本号的SQL语句，这会被下一代防火墙识别为SQL注入并拦截，同时也存在被其他被恶意截断的风险。希望修改为post方式。