### PR TITLE
Additional QueryStats metrics

### DIFF
--- a/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
+++ b/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
@@ -213,15 +213,14 @@ public class SqlSimpleSelectTests : IDisposable
 
     [Test]
     [FromVersion(23, 8)]
-    public async Task ShouldGetNullResultQueryStatsIfResponseBufferingDisabled()
+    public async Task ShouldGetEmptyResultQueryStatsIfResponseBufferingDisabled()
     {
         var command = connection.CreateCommand();
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();
         var stats = command.QueryStats;
-        Assert.IsFalse(connection.IsResponseBufferingEnabled);
-        Assert.IsNull(stats.ResultRows);
-        Assert.IsNull(stats.ResultBytes);
+        Assert.AreEqual(stats.ResultRows, 0);
+        Assert.AreEqual(stats.ResultBytes, 0);
     }
 
     [Test]
@@ -233,7 +232,6 @@ public class SqlSimpleSelectTests : IDisposable
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();
         var stats = command.QueryStats;
-        Assert.IsTrue(connection.IsResponseBufferingEnabled);
         Assert.AreEqual(stats.ResultRows, 100);
         Assert.AreEqual(stats.ResultBytes, 800);
     }

--- a/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
+++ b/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
@@ -194,10 +194,10 @@ public class SqlSimpleSelectTests : IDisposable
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();
         var stats = command.QueryStats;
-        Assert.AreEqual(stats.ReadRows, 100);
-        Assert.AreEqual(stats.ReadBytes, 800);
-        Assert.AreEqual(stats.WrittenRows, 0);
-        Assert.AreEqual(stats.WrittenBytes, 0);
+        Assert.AreEqual(100, stats.ReadRows);
+        Assert.AreEqual(800, stats.ReadBytes);
+        Assert.AreEqual(0, stats.WrittenRows);
+        Assert.AreEqual(0, stats.WrittenBytes);
     }
 
     [Test]
@@ -219,8 +219,8 @@ public class SqlSimpleSelectTests : IDisposable
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();
         var stats = command.QueryStats;
-        Assert.AreEqual(stats.ResultRows, 0);
-        Assert.AreEqual(stats.ResultBytes, 0);
+        Assert.AreEqual(0, stats.ResultRows);
+        Assert.AreEqual(0, stats.ResultBytes);
     }
 
     [Test]
@@ -232,8 +232,8 @@ public class SqlSimpleSelectTests : IDisposable
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();
         var stats = command.QueryStats;
-        Assert.AreEqual(stats.ResultRows, 100);
-        Assert.AreEqual(stats.ResultBytes, 800);
+        Assert.AreEqual(100, stats.ResultRows);
+        Assert.AreEqual(928, stats.ResultBytes);
     }
 
     [Test]

--- a/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
+++ b/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
@@ -203,7 +203,7 @@ public class SqlSimpleSelectTests : IDisposable
     }
 
     [Test]
-    [FromVersion(23, 9)]
+    [FromVersion(23, 8)]
     public async Task ShouldGetElapsedQueryStats()
     {
         var command = connection.CreateCommand();
@@ -214,20 +214,8 @@ public class SqlSimpleSelectTests : IDisposable
     }
 
     [Test]
-    [FromVersion(23, 8)]
-    public async Task ShouldGetEmptyResultQueryStatsIfResponseBufferingDisabled()
-    {
-        var command = connection.CreateCommand();
-        command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
-        using var reader = await command.ExecuteReaderAsync();
-        var stats = command.QueryStats;
-        Assert.AreEqual(0, stats.ResultRows);
-        Assert.AreEqual(0, stats.ResultBytes);
-    }
-
-    [Test]
-    [FromVersion(23, 8)]
-    public async Task ShouldGetResultQueryStatsIfResponseBufferingEnabled()
+    [FromVersion(23, 7)]
+    public async Task ShouldGetResultQueryStats()
     {
         using var bufferingConnection = TestUtilities.GetTestClickHouseConnection(useCompression);
         bufferingConnection.EnableResponseBuffering();

--- a/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
+++ b/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
@@ -218,7 +218,7 @@ public class SqlSimpleSelectTests : IDisposable
     public async Task ShouldGetResultQueryStats()
     {
         using var bufferingConnection = TestUtilities.GetTestClickHouseConnection(useCompression);
-        bufferingConnection.ForceResponseBuffering();
+        bufferingConnection.CustomSettings.Add("wait_end_of_query", 1);
         var command = bufferingConnection.CreateCommand();
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();

--- a/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
+++ b/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
@@ -218,7 +218,7 @@ public class SqlSimpleSelectTests : IDisposable
     public async Task ShouldGetResultQueryStats()
     {
         using var bufferingConnection = TestUtilities.GetTestClickHouseConnection(useCompression);
-        bufferingConnection.EnableResponseBuffering();
+        bufferingConnection.ForceResponseBuffering();
         var command = bufferingConnection.CreateCommand();
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();

--- a/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
+++ b/ClickHouse.Client.Tests/SQL/SqlSimpleSelectTests.cs
@@ -18,9 +18,11 @@ namespace ClickHouse.Client.Tests.SQL;
 public class SqlSimpleSelectTests : IDisposable
 {
     private readonly ClickHouseConnection connection;
+    private readonly bool useCompression;
 
     public SqlSimpleSelectTests(bool useCompression)
     {
+        this.useCompression = useCompression;
         connection = TestUtilities.GetTestClickHouseConnection(useCompression);
     }
 
@@ -227,8 +229,9 @@ public class SqlSimpleSelectTests : IDisposable
     [FromVersion(23, 8)]
     public async Task ShouldGetResultQueryStatsIfResponseBufferingEnabled()
     {
-        connection.EnableResponseBuffering();
-        var command = connection.CreateCommand();
+        using var bufferingConnection = TestUtilities.GetTestClickHouseConnection(useCompression);
+        bufferingConnection.EnableResponseBuffering();
+        var command = bufferingConnection.CreateCommand();
         command.CommandText = "SELECT * FROM system.numbers LIMIT 100";
         using var reader = await command.ExecuteReaderAsync();
         var stats = command.QueryStats;

--- a/ClickHouse.Client/ADO/ClickHouseCommand.cs
+++ b/ClickHouse.Client/ADO/ClickHouseCommand.cs
@@ -174,7 +174,7 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
             .ConfigureAwait(false);
 
         QueryId = ExtractQueryId(response);
-        QueryStats = ExtractQueryStats(response, connection.IsResponseBufferingEnabled);
+        QueryStats = ExtractQueryStats(response);
         activity.SetQueryStats(QueryStats);
         return await ClickHouseConnection.HandleError(response, sqlQuery, activity).ConfigureAwait(false);
     }
@@ -244,7 +244,7 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
         NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString,
     };
 
-    private static QueryStats ExtractQueryStats(HttpResponseMessage response, bool isResponseBufferingEnabled)
+    private static QueryStats ExtractQueryStats(HttpResponseMessage response)
     {
         try
         {
@@ -253,8 +253,7 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
             {
                 var value = response.Headers.GetValues(summaryHeader).FirstOrDefault();
                 var jsonDoc = JsonDocument.Parse(value);
-                var result = JsonSerializer.Deserialize<QueryStats>(value, SummarySerializerOptions);
-                return isResponseBufferingEnabled ? result : result.WithResponseBufferingDisabled();
+                return JsonSerializer.Deserialize<QueryStats>(value, SummarySerializerOptions);
             }
         }
         catch

--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -159,22 +159,6 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
         this.UseFormDataParameters = sendParametersAsFormData;
     }
 
-    public void ForceResponseBuffering(long? bufferSizeBytes = null)
-    {
-        const string bufferSizeRequestParameter = "buffer_size";
-        const string waitEndOfQueryRequestParameter = "wait_end_of_query";
-
-        customSettings.AddOrUpdate(waitEndOfQueryRequestParameter, 1, (_, _) => 1);
-
-        if (bufferSizeBytes != null)
-        {
-            customSettings.AddOrUpdate(
-                bufferSizeRequestParameter,
-                bufferSizeBytes.Value,
-                (_, _) => bufferSizeBytes.Value);
-        }
-    }
-
     /// <summary>
     /// Gets enum describing which ClickHouse features are available on this particular server version
     /// Requires connection to be in Open state

--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -159,7 +159,7 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
         this.UseFormDataParameters = sendParametersAsFormData;
     }
 
-    public void EnableResponseBuffering(long? bufferSizeBytes = null)
+    public void ForceResponseBuffering(long? bufferSizeBytes = null)
     {
         const string bufferSizeRequestParameter = "buffer_size";
         const string waitEndOfQueryRequestParameter = "wait_end_of_query";

--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -23,6 +23,9 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
 {
     private const string CustomSettingPrefix = "set_";
 
+    private const string BufferSizeRequestParameter = "buffer_size";
+    private const string WaitEndOfQueryRequestParameter = "wait_end_of_query";
+
     private readonly List<IDisposable> disposables = new();
     private readonly string httpClientName;
     private readonly ConcurrentDictionary<string, object> customSettings = new ConcurrentDictionary<string, object>();
@@ -153,10 +156,25 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
 
     public bool UseFormDataParameters { get; private set; }
 
+    public bool IsResponseBufferingEnabled => customSettings.ContainsKey(WaitEndOfQueryRequestParameter);
+
     public void SetFormDataParameters(
         bool sendParametersAsFormData)
     {
         this.UseFormDataParameters = sendParametersAsFormData;
+    }
+
+    public void EnableResponseBuffering(long? bufferSizeBytes = null)
+    {
+        customSettings.TryAdd(WaitEndOfQueryRequestParameter, 1);
+
+        if (bufferSizeBytes != null)
+        {
+            customSettings.AddOrUpdate(
+                BufferSizeRequestParameter,
+                bufferSizeBytes.Value,
+                (_, _) => bufferSizeBytes.Value);
+        }
     }
 
     /// <summary>

--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -23,9 +23,6 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
 {
     private const string CustomSettingPrefix = "set_";
 
-    private const string BufferSizeRequestParameter = "buffer_size";
-    private const string WaitEndOfQueryRequestParameter = "wait_end_of_query";
-
     private readonly List<IDisposable> disposables = new();
     private readonly string httpClientName;
     private readonly ConcurrentDictionary<string, object> customSettings = new ConcurrentDictionary<string, object>();
@@ -156,8 +153,6 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
 
     public bool UseFormDataParameters { get; private set; }
 
-    public bool IsResponseBufferingEnabled => customSettings.ContainsKey(WaitEndOfQueryRequestParameter);
-
     public void SetFormDataParameters(
         bool sendParametersAsFormData)
     {
@@ -166,12 +161,15 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
 
     public void EnableResponseBuffering(long? bufferSizeBytes = null)
     {
-        customSettings.TryAdd(WaitEndOfQueryRequestParameter, 1);
+        const string bufferSizeRequestParameter = "buffer_size";
+        const string waitEndOfQueryRequestParameter = "wait_end_of_query";
+
+        customSettings.TryAdd(waitEndOfQueryRequestParameter, 1);
 
         if (bufferSizeBytes != null)
         {
             customSettings.AddOrUpdate(
-                BufferSizeRequestParameter,
+                bufferSizeRequestParameter,
                 bufferSizeBytes.Value,
                 (_, _) => bufferSizeBytes.Value);
         }

--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -164,7 +164,7 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
         const string bufferSizeRequestParameter = "buffer_size";
         const string waitEndOfQueryRequestParameter = "wait_end_of_query";
 
-        customSettings.TryAdd(waitEndOfQueryRequestParameter, 1);
+        customSettings.AddOrUpdate(waitEndOfQueryRequestParameter, 1, (_, _) => 1);
 
         if (bufferSizeBytes != null)
         {

--- a/ClickHouse.Client/ADO/QueryStats.cs
+++ b/ClickHouse.Client/ADO/QueryStats.cs
@@ -1,5 +1,21 @@
 ﻿namespace ClickHouse.Client.ADO;
 
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
-public record class QueryStats(long ReadRows, long ReadBytes, long WrittenRows, long WrittenBytes, long TotalRowsToRead);
+
+public record QueryStats(
+    long ReadRows,
+    long ReadBytes,
+    long WrittenRows,
+    long WrittenBytes,
+    long TotalRowsToRead,
+    long? ResultRows,
+    long? ResultBytes,
+    long ElapsedNs)
+{
+    internal QueryStats WithResponseBufferingDisabled()
+    {
+        return this with { ResultRows = null, ResultBytes = null };
+    }
+}
+
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter

--- a/ClickHouse.Client/ADO/QueryStats.cs
+++ b/ClickHouse.Client/ADO/QueryStats.cs
@@ -8,14 +8,8 @@ public record QueryStats(
     long WrittenRows,
     long WrittenBytes,
     long TotalRowsToRead,
-    long? ResultRows,
-    long? ResultBytes,
-    long ElapsedNs)
-{
-    internal QueryStats WithResponseBufferingDisabled()
-    {
-        return this with { ResultRows = null, ResultBytes = null };
-    }
-}
+    long ResultRows,
+    long ResultBytes,
+    long ElapsedNs);
 
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter

--- a/ClickHouse.Client/Diagnostic/ActivitySourceHelper.cs
+++ b/ClickHouse.Client/Diagnostic/ActivitySourceHelper.cs
@@ -22,6 +22,9 @@ internal static class ActivitySourceHelper
     private const string TagReadBytes = "db.clickhouse.read_bytes";
     private const string TagWrittenRows = "db.clickhouse.written_rows";
     private const string TagWrittenBytes = "db.clickhouse.written_bytes";
+    private const string TagResultRows = "db.clickhouse.result_rows";
+    private const string TagResultBytes = "db.clickhouse.result_bytes";
+    private const string TagElapsedNs = "db.clickhouse.elapsed_ns";
 
     internal const int StatementMaxLen = 300;
 
@@ -68,6 +71,9 @@ internal static class ActivitySourceHelper
         activity.SetTag(TagReadBytes, stats.ReadBytes);
         activity.SetTag(TagWrittenRows, stats.WrittenRows);
         activity.SetTag(TagWrittenBytes, stats.WrittenBytes);
+        activity.SetTag(TagResultRows, stats.ResultRows);
+        activity.SetTag(TagResultBytes, stats.ResultBytes);
+        activity.SetTag(TagElapsedNs, stats.ElapsedNs);
     }
 
     internal static void SetSuccess(this Activity activity)


### PR DESCRIPTION
Relates to #507 

Since `result_rows` and `result_bytes` are populated only if `wait_end_of_query` parameter is set ([introduced here](https://github.com/ClickHouse/ClickHouse/pull/39567)), I added some `ClickHouseConnection` functionality to simplify enabling response buffering ([docs here](https://clickhouse.com/docs/en/interfaces/http#response-buffering)).

Initially, I decided to populate the corresponding `QueryStats` properties with **null** values if response buffering is disabled. However, it is worth noting that response buffering might be enabled through the server config parameter `http_wait_end_of_query`.