### PR TITLE
Implemented the connection protocol receiving

### DIFF
--- a/ClickHouse.Client.Tests/ConnectionTests.cs
+++ b/ClickHouse.Client.Tests/ConnectionTests.cs
@@ -194,6 +194,17 @@ public class ConnectionTests : AbstractConnectionTestFixture
     }
 
     [Test]
+    [TestCase("https")]
+    [TestCase("http")]
+    public void ShouldSaveProtocolAtConnectionString(string protocol)
+    {
+        string protocolPart = $"Protocol={protocol}";
+        string connString = new ClickHouseConnectionStringBuilder(protocolPart).ToString();
+        using var conn = new ClickHouseConnection(connString);
+        Assert.That(conn.ConnectionString, Contains.Substring(protocolPart));
+    }
+
+    [Test]
     public async Task ShouldPostDynamicallyGeneratedRawStream()
     {
         var targetTable = "test.raw_stream";

--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -384,6 +384,7 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
                 Database = database,
                 Username = username,
                 Password = password,
+                Protocol = serverUri?.Scheme,
                 Host = serverUri?.Host,
                 Port = (ushort)serverUri?.Port,
                 Compression = UseCompression,


### PR DESCRIPTION
It was noticed that the connection protocol is not returned in the `ConnectionString` property of the `ClickHouseConnection` class.