### PR TITLE
Large response outofmem fix

### DIFF
--- a/ClickHouse.Client/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Client/ADO/ClickHouseConnection.cs
@@ -218,10 +218,20 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
             activity.SetSuccess();
             return response;
         }
-        var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        var ex = ClickHouseServerException.FromServerResponse(error, query);
-        activity.SetException(ex);
-        throw ex;
+        activity.SetStatus(ActivityStatusCode.Error, response.ReasonPhrase);
+        var ex = new Exception($"Error '{response.StatusCode}' reading server response: {response.ReasonPhrase}");
+        try
+        {
+            await response.Content.LoadIntoBufferAsync(4096);
+            var stream = (MemoryStream)await response.Content.ReadAsStreamAsync();
+            var error = new StreamReader(stream).ReadToEnd();
+            ex = ClickHouseServerException.FromServerResponse(error, query);
+            activity.SetException(ex);
+        }
+        finally
+        {
+            throw ex;
+        }
     }
 
     public override void ChangeDatabase(string databaseName) => database = databaseName;


### PR DESCRIPTION
I got a situation when my multi-GB response that I was reading asynchronously got interrupted with an error code. But unfortunately, the library attempts to deserialize the entire response in memory hoping to obtain error text resulting in OOM.  
The fix employs fixed length buffer to do the same and falls back to a pre-arranged exception in case something goes wrong.