### PR TITLE
Fix issue #580: [BUG] String type SqlParameter does not support Turkish chars

### DIFF
--- a/ClickHouse.Client.Tests/ADO/UriBuilderTests.cs
+++ b/ClickHouse.Client.Tests/ADO/UriBuilderTests.cs
@@ -1,0 +1,24 @@
+using System;
+using ClickHouse.Client;
+using NUnit.Framework;
+
+namespace ClickHouse.Client.Tests.ADO
+{
+    public class UriBuilderTests
+    {
+        [Test]
+        public void ShouldEncodeTurkishCharactersCorrectly()
+        {
+            var baseUri = new Uri("http://localhost");
+            var builder = new ClickHouseUriBuilder(baseUri)
+            {
+                Sql = "SELECT * FROM table WHERE name = {PRM1:String}"
+            };
+            builder.AddSqlQueryParameter("PRM1", "Bardak Çay");
+
+            var result = builder.ToString();
+
+            Assert.IsTrue(result.Contains("param_PRM1=Bardak+%c3%87ay"));
+        }
+    }
+}

--- a/ClickHouse.Client/ClickHouseUriBuilder.cs
+++ b/ClickHouse.Client/ClickHouseUriBuilder.cs
@@ -48,8 +48,17 @@ internal class ClickHouseUriBuilder
         parameters.SetOrRemove("query", Sql);
         parameters.SetOrRemove("query_id", QueryId);
 
+        // foreach (var parameter in sqlQueryParameters)
+        //     parameters.Set("param_" + parameter.Key, HttpUtility.UrlEncode(parameter.Value));
+
+        string queryString = parameters.ToString();
+
         foreach (var parameter in sqlQueryParameters)
-            parameters.Set("param_" + parameter.Key, parameter.Value);
+        {
+            queryString = queryString + (string.IsNullOrEmpty(queryString) ? string.Empty : "&") + "param_" + parameter.Key + "=" + HttpUtility.UrlEncode(parameter.Value);
+        }
+
+        var uriBuilder = new UriBuilder(BaseUri) { Query = queryString };
 
         if (ConnectionQueryStringParameters != null)
         {


### PR DESCRIPTION
This pull request fixes #580.

The issue was successfully resolved by modifying the `ToString` method in the `ClickHouseUriBuilder` class to correctly encode Turkish characters, such as "Ç", in the query string parameters. The original implementation did not handle these characters properly, resulting in incorrect URL encoding. The changes involved using `HttpUtility.UrlEncode` to encode the parameter values when constructing the query string, ensuring that characters like "Ç" are encoded as `%c3%87` instead of `%u00c7`. Additionally, a new test case, `ShouldEncodeTurkishCharactersCorrectly`, was added to verify that the URL encoding for Turkish characters is now correct. The test checks that the resulting URL contains the correctly encoded parameter value, confirming that the issue has been addressed.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌