### PR TITLE
DynamicType | Support read

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,8 @@ jobs:
           - "23.8"
           - "23.9"
           - "24.12"
+          - "25.1"
+          - "25.3"
 
   regress-dotnet:
     name: .NET regression

--- a/ClickHouse.Client.Tests/Attributes/FromVersionAttributeTests.cs
+++ b/ClickHouse.Client.Tests/Attributes/FromVersionAttributeTests.cs
@@ -22,11 +22,10 @@ public class FromVersionAttributeTests : AbstractConnectionTestFixture
     {
         if (TestUtilities.ServerVersion != null)
         {
-            Assert.Multiple(() =>
-            {
-                Assert.That(TestUtilities.ServerVersion.Major >= 23);
-                Assert.That(TestUtilities.ServerVersion.Minor >= 3);
-            });
+            Assert.That(
+                TestUtilities.ServerVersion.Major > 23 ||
+                TestUtilities.ServerVersion.Major == 23 &&
+                TestUtilities.ServerVersion.Minor >= 3);
         }
     }
 }

--- a/ClickHouse.Client.Tests/TestUtilities.cs
+++ b/ClickHouse.Client.Tests/TestUtilities.cs
@@ -66,6 +66,10 @@ public static class TestUtilities
         {
             builder["set_allow_experimental_json_type"] = 1;
         }
+        if (SupportedFeatures.HasFlag(Feature.Dynamic))
+        {
+            builder["set_allow_experimental_dynamic_type"] = 1;
+        }
         var connection = new ClickHouseConnection(builder.ConnectionString);
         connection.Open();
         return connection;

--- a/ClickHouse.Client.Tests/TestUtilities.cs
+++ b/ClickHouse.Client.Tests/TestUtilities.cs
@@ -110,6 +110,9 @@ public static class TestUtilities
 
         yield return new DataTypeSample("Float32", typeof(float), "toFloat32(32e6)", 32e6);
         yield return new DataTypeSample("Float32", typeof(float), "toFloat32(-32e6)", -32e6);
+        
+        yield return new DataTypeSample("Float32", typeof(float), "toFloat32(1.1)", 1.1f);
+        yield return new DataTypeSample("Float32", typeof(float), "toFloat32(-1.1)", -1.1f);
 
         yield return new DataTypeSample("Float64", typeof(double), "toFloat64(64e6)", 64e6);
         yield return new DataTypeSample("Float64", typeof(double), "toFloat64(-64e6)", -64e6);

--- a/ClickHouse.Client.Tests/Types/DynamicTests.cs
+++ b/ClickHouse.Client.Tests/Types/DynamicTests.cs
@@ -1,43 +1,110 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
-using ClickHouse.Client.ADO;
 using ClickHouse.Client.ADO.Readers;
-using ClickHouse.Client.Tests.Attributes;
 using ClickHouse.Client.Utility;
 
 namespace ClickHouse.Client.Tests.Types;
 
 public class DynamicTests : AbstractConnectionTestFixture
 {
+    public static IEnumerable<TestCaseData> SimpleSelectQueries => TestUtilities.GetDataTypeSamples()
+        .Where(s => ShouldBeSupportedInJson(s.ClickHouseType))
+        .Select(sample => GetTestCaseData(sample.ExampleExpression, sample.ClickHouseType, sample.ExampleValue));
+
     [Test]
-    [RequiredFeature(Feature.Dynamic)]
-    [TestCase("null", ExpectedResult = typeof(DBNull))]
-    [TestCase("1", ExpectedResult = typeof(long))]
-    [TestCase("1000", ExpectedResult = typeof(long))]
-    [TestCase("100000", ExpectedResult = typeof(long))]
-    [TestCase("-1", ExpectedResult = typeof(long))]
-    [TestCase("1.2", ExpectedResult = typeof(double))]
-    [TestCase("-1.2", ExpectedResult = typeof(double))]
-    [TestCase("\"str\"", ExpectedResult = typeof(string))]
-    [TestCase("\"1.2.3.4\"", ExpectedResult = typeof(string))]
-    [TestCase("\"2025-04-10 20:12:07.363000000\"", ExpectedResult = typeof(DateTime))]
-    [TestCase("\"00000000-0000-0000-0000-000000000000\"", ExpectedResult = typeof(string))]
-    [TestCase("[1]", ExpectedResult = typeof(long?[]))]
-    [TestCase("[1.2]", ExpectedResult = typeof(double?[]))]
-    [TestCase("[\"str\"]", ExpectedResult = typeof(string[]))]
-    public async Task<Type> ShouldConvertToClickHouseTypeAsync(object value)
+    [TestCaseSource(typeof(DynamicTests), nameof(SimpleSelectQueries))]
+    public async Task ShouldMatchFrameworkType(string valueSql, Type frameworkType)
     {
         using var reader =
             (ClickHouseDataReader) await connection.ExecuteReaderAsync(
-                $$"""
-                  WITH t as (SELECT '{"value": {{value}}}'::JSON as json) 
-                  select json.value from t
-                  """);
+                $"select json.value from (select toJSONString(map('value', {valueSql}))::JSON as json)");
 
         ClassicAssert.IsTrue(reader.Read());
         var result = reader.GetValue(0);
+        Assert.That(result.GetType(), Is.EqualTo(frameworkType));
         ClassicAssert.IsFalse(reader.Read());
+    }
 
-        return result.GetType();
+    private static TestCaseData GetTestCaseData(string exampleExpression, string clickHouseType, object exampleValue)
+    {
+        if (clickHouseType.StartsWith("Date"))
+        {
+            return new TestCaseData(exampleExpression, typeof(DateTime));
+        }
+
+        if (clickHouseType.StartsWith("Int") || clickHouseType.StartsWith("UInt"))
+        {
+            return new TestCaseData(exampleExpression, typeof(long));
+        }
+
+        if (clickHouseType.StartsWith("FixedString"))
+        {
+            return new TestCaseData(exampleExpression, typeof(string));
+        }
+
+        if (clickHouseType.StartsWith("Float"))
+        {
+            var floatRemainder =
+                exampleValue switch
+                {
+                    double @double => @double % 10,
+                    float @float => @float % 10,
+                    _ => throw new ArgumentException($"{exampleValue.GetType().Name} not supported in for Float")
+                };
+            return new TestCaseData(
+                exampleExpression,
+                floatRemainder is 0
+                    ? typeof(long)
+                    : typeof(double));
+        }
+
+        switch (clickHouseType)
+        {
+            case "Array(Int32)" or "Array(Nullable(Int32))":
+                return new TestCaseData(exampleExpression, typeof(long?[]));
+            case "Array(String)":
+                return new TestCaseData(exampleExpression, typeof(string[]));
+            case "IPv4" or "IPv6" or "String" or "UUID":
+                return new TestCaseData(exampleExpression, typeof(string));
+            case "Nothing":
+                return new TestCaseData(exampleExpression, typeof(DBNull));
+            case "Bool":
+                return new TestCaseData(exampleExpression, typeof(bool));
+        }
+
+        throw new ArgumentException($"{clickHouseType} not supported");
+    }
+
+    private static bool ShouldBeSupportedInJson(string clickHouseType)
+    {
+        if (clickHouseType.Contains("Decimal") ||
+            clickHouseType.Contains("Enum") ||
+            clickHouseType.Contains("FixedString") ||
+            clickHouseType.Contains("LowCardinality") ||
+            clickHouseType.Contains("Map") ||
+            clickHouseType.Contains("Nested") ||
+            clickHouseType.Contains("Nullable") ||
+            clickHouseType.Contains("Tuple") ||
+            clickHouseType.Contains("Variant"))
+        {
+            return false;
+        }
+
+        switch (clickHouseType)
+        {
+            case "Date32":
+            case "Int128":
+            case "Int256":
+            case "Json":
+            case "Point":
+            case "Ring":
+            case "UInt128":
+            case "UInt256":
+                return false;
+            default:
+                return true;
+        }
     }
 }

--- a/ClickHouse.Client.Tests/Types/DynamicTests.cs
+++ b/ClickHouse.Client.Tests/Types/DynamicTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+using ClickHouse.Client.ADO.Readers;
+using ClickHouse.Client.Utility;
+
+namespace ClickHouse.Client.Tests.Types;
+
+public class DynamicTests : AbstractConnectionTestFixture
+{
+    [Test]
+    [TestCase("null", ExpectedResult = typeof(DBNull))]
+    [TestCase("1", ExpectedResult = typeof(long))]
+    [TestCase("-1", ExpectedResult = typeof(long))]
+    [TestCase("1.2", ExpectedResult = typeof(double))]
+    [TestCase("-1.2", ExpectedResult = typeof(double))]
+    [TestCase("\"str\"", ExpectedResult = typeof(string))]
+    [TestCase("\"1.2.3.4\"", ExpectedResult = typeof(string))]
+    [TestCase("\"2025-04-10 20:12:07.363000000\"", ExpectedResult = typeof(DateTime))]
+    [TestCase("\"00000000-0000-0000-0000-000000000000\"", ExpectedResult = typeof(string))]
+    [TestCase("[1]", ExpectedResult = typeof(long?[]))]
+    [TestCase("[1.2]", ExpectedResult = typeof(double?[]))]
+    [TestCase("[\"str\"]", ExpectedResult = typeof(string[]))]
+    public async Task<Type> ShouldConvertToClickHouseTypeAsync(object value)
+    {
+        using var reader =
+            (ClickHouseDataReader) await connection.ExecuteReaderAsync(
+                $$"""
+                  WITH t as (SELECT '{"value": {{value}}}'::JSON as json) 
+                  select json.value from t
+                  """);
+
+        ClassicAssert.IsTrue(reader.Read());
+        var result = reader.GetValue(0);
+        ClassicAssert.IsFalse(reader.Read());
+
+        return result.GetType();
+    }
+}

--- a/ClickHouse.Client.Tests/Types/DynamicTests.cs
+++ b/ClickHouse.Client.Tests/Types/DynamicTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
+using ClickHouse.Client.ADO;
 using ClickHouse.Client.ADO.Readers;
+using ClickHouse.Client.Tests.Attributes;
 using ClickHouse.Client.Utility;
 
 namespace ClickHouse.Client.Tests.Types;
@@ -8,8 +10,11 @@ namespace ClickHouse.Client.Tests.Types;
 public class DynamicTests : AbstractConnectionTestFixture
 {
     [Test]
+    [RequiredFeature(Feature.Dynamic)]
     [TestCase("null", ExpectedResult = typeof(DBNull))]
     [TestCase("1", ExpectedResult = typeof(long))]
+    [TestCase("1000", ExpectedResult = typeof(long))]
+    [TestCase("100000", ExpectedResult = typeof(long))]
     [TestCase("-1", ExpectedResult = typeof(long))]
     [TestCase("1.2", ExpectedResult = typeof(double))]
     [TestCase("-1.2", ExpectedResult = typeof(double))]

--- a/ClickHouse.Client/ADO/Feature.cs
+++ b/ClickHouse.Client/ADO/Feature.cs
@@ -9,38 +9,41 @@ public enum Feature
     None = 0, // Special value
 
     [SinceVersion("21.4")]
-    UUIDParameters = 32,
+    UUIDParameters = 1,
 
     [SinceVersion("21.4")]
-    Map = 64,
+    Map = 1 << 1,
 
     [SinceVersion("21.12")]
-    Bool = 128,
+    Bool = 1 << 2,
 
     [SinceVersion("21.9")]
-    Date32 = 256,
+    Date32 = 1 << 3,
 
     [SinceVersion("21.9")]
-    WideTypes = 512,
+    WideTypes = 1 << 4,
 
     [Obsolete]
     [SinceVersion("20.5")]
-    Geo = 1024,
+    Geo = 1 << 5,
 
     [SinceVersion("22.6")]
-    Stats = 2048,
+    Stats = 1 << 6,
 
     [SinceVersion("22.8")]
-    AsyncInsert = 8192,
+    AsyncInsert = 1 << 7,
 
     [SinceVersion("24.1")]
-    Variant = 16384,
+    Variant = 1 << 8,
 
     [SinceVersion("22.3")]
-    ParamsInMultipartFormData = 32768,
+    ParamsInMultipartFormData = 1 << 9,
 
     [SinceVersion("24.1")]
-    Json = 65536,
+    Json = 1 << 10,
+
+    [SinceVersion("25.1")]
+    Dynamic = 1 << 11,
 
     All = ~None, // Special value
 }

--- a/ClickHouse.Client/Types/DynamicType.cs
+++ b/ClickHouse.Client/Types/DynamicType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using ClickHouse.Client.Formats;
+
+namespace ClickHouse.Client.Types;
+
+internal class DynamicType : ClickHouseType
+{
+    public override Type FrameworkType => typeof(object);
+
+    public override string ToString() => "Dynamic";
+
+    public override object Read(ExtendedBinaryReader reader) =>
+        TypeConverter.
+            FromByteCode(reader).
+            Read(reader);
+
+    public override void Write(ExtendedBinaryWriter writer, object value) =>
+        throw new NotImplementedException();
+}

--- a/ClickHouse.Client/Types/TypeConverter.cs
+++ b/ClickHouse.Client/Types/TypeConverter.cs
@@ -127,6 +127,7 @@ internal static class TypeConverter
         RegisterPlainType<Float64Type>();
 
         // Special types
+        RegisterPlainType<DynamicType>();
         RegisterPlainType<UuidType>();
         RegisterPlainType<IPv4Type>();
         RegisterPlainType<IPv6Type>();
@@ -337,7 +338,7 @@ internal static class TypeConverter
             case 0x28: return new IPv4Type();
             case 0x29: return new IPv6Type();
             // case 0x2A: return new VariantType(); // TODO nested types
-            // case 0x2B: return new VariantType(); // TODO max types
+            case 0x2B: return new DynamicType();
             // case 0x2C: return new RingType(); // TODO custom type
             case 0x2D: return new BooleanType();
             // case 0x2E: return new SimpleAggregateFunctionType(); // TODO function

--- a/ClickHouse.Client/Types/TypeConverter.cs
+++ b/ClickHouse.Client/Types/TypeConverter.cs
@@ -318,8 +318,8 @@ internal static class TypeConverter
             case 0x14: return new DateTime64Type() { Scale = reader.Read7BitEncodedInt(), TimeZone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(reader.ReadString()) };
             case 0x15: return new StringType();
             case 0x16: return new FixedStringType() { Length = reader.Read7BitEncodedInt() };
-            //case 0x17: return new Enum8Type(); // TODO values
-            //case 0x18: return new Enum16Type(); // TODO values
+            // case 0x17: return new Enum8Type(); // TODO values
+            // case 0x18: return new Enum16Type(); // TODO values
             // case 0x19: return new Decimal32Type(); // TODO precision and scale
             // case 0x1A: return new Decimal64Type(); // TODO precision and scale
             // case 0x1B: return new Decimal128Type(); // TODO precision and scale
@@ -351,8 +351,7 @@ internal static class TypeConverter
             default:
                 break;
         }
-        ;
+
         throw new ArgumentOutOfRangeException(nameof(value), $"Unknown type: {value}");
     }
 }
-


### PR DESCRIPTION
minimum support for reading Dynamic type.
this is required for reading values from the new JSON supported type.