### PR TITLE
Add RecyclableMemoryStreamManager configuration

### DIFF
--- a/ClickHouse.Client/Copy/BulkCopyDefaultSettings.cs
+++ b/ClickHouse.Client/Copy/BulkCopyDefaultSettings.cs
@@ -1,0 +1,11 @@
+using Microsoft.IO;
+
+namespace ClickHouse.Client.Copy;
+
+internal static class BulkCopyDefaultSettings
+{
+    public static readonly RecyclableMemoryStreamManager MemoryStreamManager = new();
+    public static readonly int BatchSize = 100000;
+    public static readonly int MaxDegreeOfParallelism = 4;
+    public static readonly RowBinaryFormat RowBinaryFormat = RowBinaryFormat.RowBinary;
+}

--- a/ClickHouse.Client/Copy/ClickHouseBulkCopy.cs
+++ b/ClickHouse.Client/Copy/ClickHouseBulkCopy.cs
@@ -16,7 +16,7 @@ namespace ClickHouse.Client.Copy;
 
 public class ClickHouseBulkCopy : IDisposable
 {
-    private static readonly RecyclableMemoryStreamManager MemoryStreamManager = new();
+    private static RecyclableMemoryStreamManager MemoryStreamManager;
     private readonly ClickHouseConnection connection;
     private readonly BatchSerializer batchSerializer;
     private readonly RowBinaryFormat rowBinaryFormat;
@@ -72,6 +72,11 @@ public class ClickHouseBulkCopy : IDisposable
     /// </summary>
     public IReadOnlyCollection<string> ColumnNames { get; init; }
 
+    /// <summary>
+    /// RecyclableMemoryStreamManager configuration options
+    /// </summary>
+    public RecyclableMemoryStreamManager.Options MemoryStreamManagerOptions { get; init; } = new();
+
     public sealed class BatchSentEventArgs : EventArgs
     {
         internal BatchSentEventArgs(long rowsWritten)
@@ -107,6 +112,7 @@ public class ClickHouseBulkCopy : IDisposable
     {
         if (DestinationTableName is null)
             throw new InvalidOperationException($"{nameof(DestinationTableName)} is null");
+        MemoryStreamManager ??= new RecyclableMemoryStreamManager(MemoryStreamManagerOptions);
         columnNamesAndTypes = await LoadNamesAndTypesAsync(DestinationTableName, ColumnNames).ConfigureAwait(false);
     }
 

--- a/ClickHouse.Client/Copy/ClickHouseBulkCopy.cs
+++ b/ClickHouse.Client/Copy/ClickHouseBulkCopy.cs
@@ -16,7 +16,7 @@ namespace ClickHouse.Client.Copy;
 
 public class ClickHouseBulkCopy : IDisposable
 {
-    private static RecyclableMemoryStreamManager MemoryStreamManager;
+    private static RecyclableMemoryStreamManager memoryStreamManager;
     private readonly ClickHouseConnection connection;
     private readonly BatchSerializer batchSerializer;
     private readonly RowBinaryFormat rowBinaryFormat;
@@ -112,7 +112,7 @@ public class ClickHouseBulkCopy : IDisposable
     {
         if (DestinationTableName is null)
             throw new InvalidOperationException($"{nameof(DestinationTableName)} is null");
-        MemoryStreamManager ??= new RecyclableMemoryStreamManager(MemoryStreamManagerOptions);
+        memoryStreamManager ??= new RecyclableMemoryStreamManager(MemoryStreamManagerOptions);
         columnNamesAndTypes = await LoadNamesAndTypesAsync(DestinationTableName, ColumnNames).ConfigureAwait(false);
     }
 
@@ -182,7 +182,7 @@ public class ClickHouseBulkCopy : IDisposable
     {
         using (batch) // Dispose object regardless whether sending succeeds
         {
-            using var stream = MemoryStreamManager.GetStream(nameof(SendBatchAsync));
+            using var stream = memoryStreamManager.GetStream(nameof(SendBatchAsync));
             // Async serialization
             await Task.Run(() => batchSerializer.Serialize(batch, stream), token).ConfigureAwait(false);
             // Seek to beginning as after writing it's at end


### PR DESCRIPTION
Hello!

While analyzing production issues with applications using `Clickhouse.Client` under high load, we observed frequent `System.OutOfMemoryException` crashes. Memory dumps and traces revealed that most of the retained memory was held by `RecyclableMemoryStreamManager`.

`Clickhouse.Client` uses `RecyclableMemoryStreamManager`, but does not allow consumers to configure it. However, as [Microsoft.IO.RecyclableMemoryStream documentation](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream) and [StackOverflow tips](https://stackoverflow.com/questions/77287155/memory-leak-with-io-recyclablememorystream) indicate, that options `MaximumLargePoolFreeBytes` and `MaximumSmallPoolFreeBytes`  options are important to preventing unbounded memory growth.

> _"If you do not set MaximumFreeLargePoolBytes and MaximumFreeSmallPoolBytes there is the possibility for unbounded memory growth, which is essentially indistinguishable from a memory leak."_ 

> _"If you set these to 0 (`MaximumFreeSmallPoolBytes` and `MaximumFreeLargePoolBytes`), you can have unbounded pool growth, which is essentially indistinguishable from a memory leak."_

---

Made the initialization of RecyclableMemoryStreamManager lazy and added the ability to set options for it. I hope this helps to fix memory leaks and OOM exceptions.

Please see the pull request. Thanks!