### PR TITLE
Fixed leak from array pool object not returned

### DIFF
--- a/ClickHouse.Client/Utility/EnumerableExtensions.cs
+++ b/ClickHouse.Client/Utility/EnumerableExtensions.cs
@@ -39,8 +39,16 @@ public static class EnumerableExtensions
                 array = ArrayPool<T>.Shared.Rent(batchSize);
             }
         }
+
         if (counter > 0)
+        {
             yield return (array, counter);
+        }
+
+        if (counter == 0)
+        {
+            ArrayPool<T>.Shared.Return(array);
+        }
     }
 
     internal static IEnumerable<T> SkipLast1<T>(this IEnumerable<T> source, int count)


### PR DESCRIPTION
Currently, if the number of elements % `batchSize` is equal to zero (meaning number of elements is zero or is a multiple of `batchSize`), the last array rented from the pool is not returned, which could lead to a memory leak.  

A fix is to simply return it if the `counter` is at 0.

Full repro:

```chsarp
using System.Buffers;

class Program
{
    const int ELEMENTS = 50000;

    static void Main(string[] args)
    {
        while (true)
        {
            foreach ((int[] array, _) in Enumerable.Range(0, ELEMENTS).BatchRented(10000))
            {
                ArrayPool<int>.Shared.Return(array);
                Interlocked.Decrement(ref ClickhouseExtensions.RentedCount);
            }
            Console.WriteLine($"RentedCount: {ClickhouseExtensions.RentedCount}");
        }
    }
}

public static class ClickhouseExtensions
{
    public static long RentedCount;

    public static IEnumerable<(T[], int)> BatchRented<T>(this IEnumerable<T> enumerable, int batchSize)
    {
        var array = ArrayPool<T>.Shared.Rent(batchSize);
        Interlocked.Increment(ref RentedCount);
        int counter = 0;

        foreach (var item in enumerable)
        {
            array[counter++] = item;

            if (counter >= batchSize)
            {
                yield return (array, counter);
                counter = 0;
                array = ArrayPool<T>.Shared.Rent(batchSize);
                Interlocked.Increment(ref RentedCount);
            }
        }
        if (counter > 0)
            yield return (array, counter);
    }
}
```

The `RentedCount` will increase forever if `ELEMENTS` is zero or a multiple of the `batchSize` (10000 here). The fix in this PR fixes the issue.